### PR TITLE
debug version should be based on master (current dev branch) instead of staging (release branch)

### DIFF
--- a/.github/workflows/buildDebug.yml
+++ b/.github/workflows/buildDebug.yml
@@ -2,7 +2,7 @@ name: Build Debug
 
 on:
   push:
-    branches: [ staging ]
+    branches: [ master, staging ]
     paths:
       - 'app/**'
       - 'gradle/**'


### PR DESCRIPTION
## :memo:  Brief description

<!-- Write you description here -->

<!-- Diff summary - START -->
smart²
Update pullRequest.yml
Improved Chinese translations
debug version should be based on master (current dev branch) instead of staging (release branch)
<!-- Diff summary - END -->


## :computer:  Commits
<!-- Diff commits - START -->
* a88bb00 - Josua Lengwenath - 2021-10-21 23:58:44 
  debug version should be based on master (current dev branch) instead of staging (release branch)
  
* 9a9488e - DerBot7214 - 2021-10-21 23:51:56 
| Improved Chinese translations
| merge from master to staging #46 
* a39fab4 - DerBot7214 - 2021-10-21 00:43:34 
| Update pullRequest.yml
| 
* 6ed520e - Josua Lengwenath - 2021-10-20 11:57:02 
  smart²
<!-- Diff commits - END -->


## :file_folder:  Modified files
<!-- Diff files - START -->
 .github/workflows/buildDebug.yml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
<!-- Diff files - END -->