### PR TITLE
Lifecycle fix

### DIFF
--- a/.github/workflows/buildCi.yml
+++ b/.github/workflows/buildCi.yml
@@ -250,7 +250,7 @@ jobs:
 
       - name: Send Telegram message
         if: steps.extract_branch.outputs.BRANCH_NAME == 'rCompatible-Dev'
-        run: "curl --location --request POST 'https://api.telegram.org/bot${{ secrets.TELEGRAM_TOKEN }}/sendMessage' --header 'Content-Type:application/json' --data-raw '{\"chat_id\":\"${{ secrets.TELEGRAM_CHANNEL_ID }}\",\"text\":\"**${{ steps.extract_branch.outputs.BRANCH_NAME }}**\\n\\ncommit: `${{ github.event.head_commit.message }}` [${{ github.event.head_commit.id }}](${{ github.event.head_commit.url }})\"}}'"
+        run: "curl --location --request POST 'https://api.telegram.org/bot${{ secrets.TELEGRAM_TOKEN }}/sendMessage' --header 'Content-Type:application/json' --data-raw '{\"chat_id\":\"${{ secrets.TELEGRAM_CHANNEL_ID }}\",\"text\":\"**${{ steps.extract_branch.outputs.BRANCH_NAME }}**\\n\\ncommit: `${{ github.event.head_commit.message }}` [${{ github.event.head_commit.id }}](${{ github.event.head_commit.url }})\",\"parse_mode\":\"markdown\"}}'"
 
       - name: Send Telegram message
         if: steps.extract_branch.outputs.BRANCH_NAME == 'rCompatible'

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "de.dertyp7214.rboardthememanager"
         minSdk = 23
         targetSdk = 32
-        versionCode = 350000
-        versionName = "3.5.0"
+        versionCode = 351000
+        versionName = "3.5.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/de/dertyp7214/rboardthememanager/core/OnBackPressedDispatcher.kt
+++ b/app/src/main/java/de/dertyp7214/rboardthememanager/core/OnBackPressedDispatcher.kt
@@ -1,0 +1,15 @@
+package de.dertyp7214.rboardthememanager.core
+
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.OnBackPressedDispatcher
+import androidx.lifecycle.LifecycleOwner
+
+fun OnBackPressedDispatcher.addCallback(lifecycleOwner: LifecycleOwner, enabled: Boolean, callback: (OnBackPressedCallback) -> Unit, body: OnBackPressedCallback.() -> Unit) {
+    val backPressedCallback = object : OnBackPressedCallback(enabled) {
+        override fun handleOnBackPressed() {
+            body()
+        }
+    }
+    callback(backPressedCallback)
+    addCallback(lifecycleOwner, backPressedCallback)
+}

--- a/app/src/main/java/de/dertyp7214/rboardthememanager/screens/MainActivity.kt
+++ b/app/src/main/java/de/dertyp7214/rboardthememanager/screens/MainActivity.kt
@@ -17,7 +17,7 @@ import android.view.View.VISIBLE
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
-import androidx.activity.addCallback
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
@@ -72,6 +72,8 @@ class MainActivity : AppCompatActivity() {
     private lateinit var mainViewModel: MainViewModel
 
     private lateinit var binding: ActivityMainBinding
+
+    private val callbacks: ArrayList<OnBackPressedCallback> = arrayListOf()
 
     @SuppressLint("NotifyDataSetChanged", "ShowToast")
     @RequiresApi(Build.VERSION_CODES.R)
@@ -139,7 +141,8 @@ class MainActivity : AppCompatActivity() {
                 }
             }
 
-        onBackPressedDispatcher.addCallback(this, true) {
+        callbacks.forEach { it.remove() }
+        onBackPressedDispatcher.addCallback(this, true, callbacks::add) {
             when {
                 bottomSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED ->
                     bottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
@@ -726,5 +729,9 @@ class MainActivity : AppCompatActivity() {
                 Log.d("ERROR", it?.serverErrorMessage ?: "NOO")
             }
         }.start()
+    }
+    override fun onDestroy() {
+        callbacks.forEach { it.remove() }
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/de/dertyp7214/rboardthememanager/screens/PreferencesActivity.kt
+++ b/app/src/main/java/de/dertyp7214/rboardthememanager/screens/PreferencesActivity.kt
@@ -6,12 +6,13 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
-import androidx.activity.addCallback
+import androidx.activity.OnBackPressedCallback
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import de.Maxr1998.modernpreferences.PreferencesAdapter
+import de.dertyp7214.rboardthememanager.core.addCallback
 import de.dertyp7214.rboardthememanager.databinding.ActivityPreferencesBinding
 import de.dertyp7214.rboardthememanager.preferences.Preferences
 import de.dertyp7214.rboardthememanager.utils.doAsync
@@ -22,6 +23,8 @@ class PreferencesActivity : AppCompatActivity() {
     private lateinit var binding: ActivityPreferencesBinding
     private lateinit var preferences: Preferences
     private lateinit var recyclerView: RecyclerView
+
+    private val callbacks: ArrayList<OnBackPressedCallback> = arrayListOf()
 
     @SuppressLint("NotifyDataSetChanged")
     @RequiresApi(Build.VERSION_CODES.R)
@@ -77,7 +80,8 @@ class PreferencesActivity : AppCompatActivity() {
             recyclerView.adapter = it
             preferences.onStart(recyclerView, it)
         }
-        onBackPressedDispatcher.addCallback(this, true) {
+        callbacks.forEach { it.remove() }
+        onBackPressedDispatcher.addCallback(this, true, callbacks::add) {
             preferences.onBackPressed {
                 isEnabled = false
                 onBackPressedDispatcher.onBackPressed()
@@ -100,5 +104,8 @@ class PreferencesActivity : AppCompatActivity() {
         onBackPressedDispatcher.onBackPressed()
         return true
     }
-
+    override fun onDestroy() {
+        callbacks.forEach { it.remove() }
+        super.onDestroy()
+    }
 }

--- a/app/src/main/java/de/dertyp7214/rboardthememanager/screens/ShareFlags.kt
+++ b/app/src/main/java/de/dertyp7214/rboardthememanager/screens/ShareFlags.kt
@@ -7,13 +7,14 @@ import android.os.Build
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
-import androidx.activity.addCallback
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
 import de.dertyp7214.rboardthememanager.R
 import de.dertyp7214.rboardthememanager.adapter.ShareFlagsAdapter
 import de.dertyp7214.rboardthememanager.components.LayoutManager
 import de.dertyp7214.rboardthememanager.components.SearchBar
+import de.dertyp7214.rboardthememanager.core.addCallback
 import de.dertyp7214.rboardthememanager.core.getMapExtra
 import de.dertyp7214.rboardthememanager.core.setXmlValue
 import de.dertyp7214.rboardthememanager.core.share
@@ -31,6 +32,8 @@ class ShareFlags : AppCompatActivity() {
     private lateinit var searchBar: SearchBar
     private var import: Boolean = false
     private var titleRes: Int = R.string.share_flags_title
+
+    private val callbacks: ArrayList<OnBackPressedCallback> = arrayListOf()
 
     @SuppressLint("NotifyDataSetChanged")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -86,7 +89,8 @@ class ShareFlags : AppCompatActivity() {
             adapter.notifyDataSetChanged()
         }
 
-        onBackPressedDispatcher.addCallback(this, true) {
+        callbacks.forEach { it.remove() }
+        onBackPressedDispatcher.addCallback(this, true, callbacks::add) {
             if (searchBar.focus) searchBar.clearText()
             else {
                 isEnabled = false
@@ -147,6 +151,7 @@ class ShareFlags : AppCompatActivity() {
 
 
     override fun onDestroy() {
+        callbacks.forEach { it.remove() }
         super.onDestroy()
         flags = mapOf()
     }

--- a/app/src/main/java/de/dertyp7214/rboardthememanager/utils/AppStartUp.kt
+++ b/app/src/main/java/de/dertyp7214/rboardthememanager/utils/AppStartUp.kt
@@ -108,22 +108,10 @@ class AppStartUp(private val activity: AppCompatActivity) {
 
             Shell.enableVerboseLogging = PreferenceManager.getDefaultSharedPreferences(this)
                 .getString("logMode", "VERBOSE") == "VERBOSE"
-            Shell.setDefaultBuilder(Shell.Builder.create().apply {
-                setFlags(Shell.FLAG_MOUNT_MASTER)
-            })
-
-            val importFlagsResultLauncher =
-                registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-                    val resultData = result.data
-                    if (result.resultCode == AppCompatActivity.RESULT_OK && resultData != null) {
-                        val size = resultData.getIntExtra("size", 0)
-                        Toast.makeText(
-                            this,
-                            getString(R.string.flags_loaded, size),
-                            Toast.LENGTH_SHORT
-                        ).show()
-                    }
-                }
+            if (Shell.getCachedShell() == null) Shell.setDefaultBuilder(
+                Shell.Builder.create().apply {
+                    setFlags(Shell.FLAG_MOUNT_MASTER)
+                })
 
             val rootAccess = hasRoot(this)
 
@@ -211,6 +199,18 @@ class AppStartUp(private val activity: AppCompatActivity) {
                 "getprop ro.com.google.ime.theme_file".runAsCommand {
                     if (it.first().isNotEmpty()) Config.lightTheme = it.first()
                 }
+                val importFlagsResultLauncher =
+                    registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+                        val resultData = result.data
+                        if (result.resultCode == AppCompatActivity.RESULT_OK && resultData != null) {
+                            val size = resultData.getIntExtra("size", 0)
+                            Toast.makeText(
+                                this,
+                                getString(R.string.flags_loaded, size),
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        }
+                    }
 
                 GboardUtils.flagsChanged { flags ->
                     isReady = true


### PR DESCRIPTION
## :memo:  Brief description

<!-- Write you description here -->

<!-- Diff summary - START -->
Add Initial Support For Android 6 and 7.x (Test), Props, deeplinking, viewmodel fix, Gradle and translation update
Props fix
New buildscript
Fix app update install on Android M/N (Android 6-7.x download this update manually), performance (logging)
Update BuildScript, Fix app update on Android M/N (Hopefully permanently)
Include theme names and file size in download tab, Update README.md
Update README.md
Merge pull request #75 from DerTyp7214/rCompatible-Dev
Merge pull request #77 from DerTyp7214/rCompatible-Dev
Merge pull request #79 from DerTyp7214/rCompatible-Dev
 Update Italian <!-- Diff summary - START -->
<!-- Diff summary - END --> Vi translation, Version bump, Preview Dialog for themes in theme packs before downloading
Show if theme has update, SDK 32, Reworked repos, small theme fixes, Fix FAB button position and Repo popup, update translation and gradle
Merge pull request #90 from DerTyp7214/rCompatible-Dev
Added Monochrome Icon, Dependencies Update, SDK Tiramisu Update, Some flags and props modification, Rewrite update installation
Add Collapsing action bar, Add options to clear the cache and recent emojis, Grammar fix, bump version to 3.4.7
Update libs, Fix sounds and theme import for old Androids, Version bump
Application startup fix for A13 Beta1 and above
Libs Update
Magisk stuff, version bump, lib updates, back handling changes, new flags, update workflow files
Fix icon alpha
Lifecycle fix
<!-- Diff summary - END -->


## :computer:  Commits
<!-- Diff commits - START -->
* e062933 - Akos Paha - 2022-05-20 14:41:19 
  Lifecycle fix
  
* e4bc6cb - Akos Paha - 2022-05-20 01:10:57 
| Fix icon alpha
| 
* 4e620a7 - Akos Paha - 2022-05-20 00:33:26 
| Magisk stuff, version bump, lib updates, back handling changes, new flags, update workflow files
| 
* d4e1e7b - Akos Paha - 2022-05-15 21:42:35 
| Libs Update
| 
* 1aecaf7 - Akos Paha - 2022-04-27 11:22:57 
| Application startup fix for A13 Beta1 and above
| 
* 6346116 - Akos Paha - 2022-04-24 19:15:41 
| Update libs, Fix sounds and theme import for old Androids, Version bump
| 
* 3757362 - Akos Paha - 2022-03-21 22:55:56 
| Add Collapsing action bar, Add options to clear the cache and recent emojis, Grammar fix, bump version to 3.4.7
| 
* 1c4c38b - Akos Paha - 2022-03-10 20:04:09 
| Added Monochrome Icon, Dependencies Update, SDK Tiramisu Update, Some flags and props modification, Rewrite update installation
| 
* 85e0085 - Akos Paha - 2022-01-31 17:04:43 
| Merge pull request #90 from DerTyp7214/rCompatible-Dev
| Cleanup and protobuf, translation and some fix, versionCode bump, system auto application theme fix for Android 10 and above
| 
* 4b054a5 - Akos Paha - 2021-12-15 12:05:56 
| Show if theme has update, SDK 32, Reworked repos, small theme fixes, Fix FAB button position and Repo popup, update translation and gradle
| Update build.gradle.kts
* 24c7b09 - Akos Paha - 2021-11-28 21:44:14 
|  Update Italian <!-- Diff commits - START -->
<!-- Diff commits - END --> Vi translation, Version bump, Preview Dialog for themes in theme packs before downloading
| 
* 5072811 - Akos Paha - 2021-11-21 10:59:10 
| Merge pull request #79 from DerTyp7214/rCompatible-Dev
| Update translations
* 3defb33 - Akos Paha - 2021-11-21 10:51:39 
| Merge pull request #77 from DerTyp7214/rCompatible-Dev
| 
* a0b729c - Akos Paha - 2021-11-20 23:11:59 
| Merge pull request #75 from DerTyp7214/rCompatible-Dev
| 
* 013276b - Akos Paha - 2021-11-20 23:08:05 
| Update README.md
| 
* 22940ab - Akos Paha - 2021-11-20 22:44:15 
| Include theme names and file size in download tab, Update README.md
| 
* e28fbd7 - Akos Paha - 2021-11-19 13:27:54 
| Update BuildScript, Fix app update on Android M/N (Hopefully permanently)
| 
* 2c70716 - Akos Paha - 2021-11-18 20:28:56 
| Fix app update install on Android M/N (Android 6-7.x download this update manually), performance (logging)
| 
* e7aeb28 - Akos Paha - 2021-11-18 14:18:21 
| New buildscript
| 
* 4468482 - Akos Paha - 2021-11-18 12:26:03 
| Props fix
| 
* 4079fda - Akos Paha - 2021-11-18 09:22:54 
  Add Initial Support For Android 6 and 7.x (Test), Props, deeplinking, viewmodel fix, Gradle and translation update
  Add Initial Support For Android 6 and 7.x (Test), Props, deeplinking, viewmodel fix, Gradle and translation update
<!-- Diff commits - END -->


## :file_folder:  Modified files
<!-- Diff files - START -->
 .github/workflows/buildCi.yml                      |  2 +-
 app/build.gradle.kts                               |  4 +--
 .../core/OnBackPressedDispatcher.kt (new)          | 15 ++++++++++
 .../rboardthememanager/screens/MainActivity.kt     | 11 ++++++--
 .../screens/PreferencesActivity.kt                 | 13 +++++++--
 .../rboardthememanager/screens/ShareFlags.kt       |  9 ++++--
 .../rboardthememanager/utils/AppStartUp.kt         | 32 +++++++++++-----------
 7 files changed, 60 insertions(+), 26 deletions(-)
<!-- Diff files - END -->