### PR TITLE
Enable Rboard Patcher Menu option for Android 6 & 7.x, Update Libs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -128,5 +128,5 @@ dependencies {
 
     debugImplementation(libs.androidx.ui.tooling)
     implementation(libs.kotlin.reflect)
-    coreLibraryDesugaring(libs.desugar.jdk.libs)
+    coreLibraryDesugaring(libs.desugar.jdk.libs.nio)
 }

--- a/app/src/main/java/de/dertyp7214/rboardthememanager/screens/MainActivity.kt
+++ b/app/src/main/java/de/dertyp7214/rboardthememanager/screens/MainActivity.kt
@@ -503,8 +503,7 @@ class MainActivity : AppCompatActivity() {
                                     menuItems.add(
                                         MenuItem(
                                             R.drawable.ic_patch,
-                                            R.string.patch,
-                                            Build.VERSION.SDK_INT > Build.VERSION_CODES.N
+                                            R.string.patch
                                         ) {
                                             val patcherPackage =
                                                 if (PackageUtils.isPackageInstalled(
@@ -551,7 +550,7 @@ class MainActivity : AppCompatActivity() {
                                     )
                                     menuItems.add(
                                         MenuItem(
-                                            R.drawable.ic_trash,
+                                            R.drawable.ic_delete,
                                             R.string.delete_theme
                                         ) {
                                             openDialog(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ commons-text = "1.10.0"
 constraintlayout = "2.2.0-alpha12"
 core = "1.12.0"
 core-ktx = "1.12.0"
-desugar_jdk_libs = "2.0.3"
+desugar_jdk_libs_nio = "2.0.3"
 espresso-core = "3.6.0-alpha01"
 firebase-bom = "32.3.1"
 firebase-analytics = "21.3.0"
@@ -19,7 +19,7 @@ firebase-messaging-ktx = "23.2.1"
 flagkit-android = "1.0.2"
 fragment-ktx = "1.7.0-alpha05"
 googleServices = "4.4.0"
-gradle = "8.3.0-alpha05"
+gradle = "8.3.0-alpha06"
 gson = "2.10.1"
 insetter = "0.6.1"
 junit = "4.13.2"
@@ -46,7 +46,7 @@ appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat"
 androidx-browser = { module = "androidx.browser:browser", version.ref = "browser" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
 androidx-core = { module = "androidx.core:core", version.ref = "core" }
-desugar_jdk_libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar_jdk_libs" }
+desugar_jdk_libs_nio = { module = "com.android.tools:desugar_jdk_libs_nio", version.ref = "desugar_jdk_libs_nio" }
 espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso-core" }
 androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragment-ktx" }
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-junit" }


### PR DESCRIPTION
`Rboard Patcher is now available on Play Store for Android 6 and 7.x
`

New dependencies changes:
• Update com.android.tools.build:gradle to 8.3.0-alpha06 
• Switch to com.android.tools:desugar_jdk_libs_nio 2.0.3