### PR TITLE
Copy Flags Fix

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "de.dertyp7214.rboardthememanager"
         minSdk = 23
         targetSdk = 36
-        versionCode = 395005
+        versionCode = 395006
         versionName = "3.9.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/de/dertyp7214/rboardthememanager/preferences/Settings.kt
+++ b/app/src/main/java/de/dertyp7214/rboardthememanager/preferences/Settings.kt
@@ -235,6 +235,7 @@ class Settings(private val activity: Activity, private val args: SafeJSON) : Abs
             {
                 val xmlFile = XMLFile(path = FLAG_PATH)
                 xmlFile.setValue(XMLEntry("crowdsource_uri", "", XMLType.STRING))
+                xmlFile.setValue(XMLEntry("llm_pc_gemma_prompt_tag_end", "", XMLType.STRING))
                 SuFile(Flags.FILES.FLAGS.filePath).writeFile(xmlFile.toString())
                 val uid = getPackageUid(
                     Config.GBOARD_PACKAGE_NAME,

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -318,4 +318,7 @@
     <string name="system_automatic_reset_question">Redefinir tema automático do sistema</string>
     <string name="system_automatic_reset_long_question">Deseja redefinir o tema automático do sistema e forçar a parada do Gboard?</string>
     <string name="newTag">Novo</string>
+    <string name="succesful_copied">Copiado com sucesso</string>
+    <string name="enable_text_preview">Prévia do texto</string>
+    <string name="enable_text_preview_details">Mostre uma prévia do texto acima do teclado</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ preference-ktx = "1.2.1"
 protobuf-dynamic = "1.0.1"
 simple-item-decoration = "1.0.0"
 ui-tooling = "1.9.0-beta02"
-r8 = "8.12.14-dev"
+r8 = "8.13.0-dev"
 
 [libraries]
 android-shell = { module = "com.jaredrummler:android-shell", version.ref = "android-shell" }


### PR DESCRIPTION
• Bump versionCode to 395006 (3.9.5)
• Delete llm_pc_gemma_prompt_tag_end value when copying a flag to fix flag loading
 • Update portuguese translation